### PR TITLE
android gcm receiver part notifcation format change

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,8 +24,8 @@ android {
         applicationId "com.mapzip.ppang.mapzipproject"
         minSdkVersion 15
         targetSdkVersion 23
-        versionCode 5
-        versionName "1.5"
+        versionCode 6
+        versionName "1.6"
     }
     buildTypes {
         release {

--- a/app/src/main/java/com/mapzip/ppang/mapzipproject/gcm/MyGcmListenerService.java
+++ b/app/src/main/java/com/mapzip/ppang/mapzipproject/gcm/MyGcmListenerService.java
@@ -12,6 +12,7 @@ import android.util.Log;
 
 import com.google.android.gms.gcm.GcmListenerService;
 import com.mapzip.ppang.mapzipproject.R;
+import com.mapzip.ppang.mapzipproject.adapter.MapzipApplication;
 import com.mapzip.ppang.mapzipproject.main.SplashActivity;
 
 import org.json.JSONException;
@@ -33,6 +34,8 @@ public class MyGcmListenerService extends GcmListenerService {
     public void onMessageReceived(String from, Bundle data) {
         String title = data.getString("title");
         String message = data.getString("message");
+        String notification_type = data.getString("notification_type"); // 보낼때는 Boolean 을 기대하지만, 보내지는 값은 string 입니다
+        MapzipApplication.doLogging(TAG, data.toString());
         JSONObject json_extra=null;
         try {
             json_extra = new JSONObject(data.getString("extra"));
@@ -40,13 +43,14 @@ public class MyGcmListenerService extends GcmListenerService {
             Log.d(TAG, "Title: " + title);
             Log.d(TAG, "Message: " + message);
             Log.d(TAG, "extra : "+json_extra.toString());
-            Log.d(TAG, "extra : notification_type : " + json_extra.getBoolean("notification_type"));
-            if(json_extra.getBoolean("notification_type")){
+            if(notification_type.equals("true")){
                 sendNotification(title, message);
             }else{
                 // no not notification
             }
         } catch (JSONException e) {
+            e.printStackTrace();
+        }catch (NullPointerException e){
             e.printStackTrace();
         }
 

--- a/app/src/main/java/com/mapzip/ppang/mapzipproject/model/SystemMain.java
+++ b/app/src/main/java/com/mapzip/ppang/mapzipproject/model/SystemMain.java
@@ -159,7 +159,7 @@ public class SystemMain {
 
     // Build Version Code
     public class Build{
-        public static final int GARNET = 5; // 가넷, 1월의 탄생석 // versionCode 5, versionName "1.5"
+        public static final int GARNET = 6; // 가넷, 1월의 탄생석 // versionCode 6, versionName "1.6"
         public static final int GARNET_END = 100;
     }
 

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -18,7 +18,7 @@
             android:layout_width="250dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="100dp"
-            android:layout_centerHorizontal="true"
+            android:layout_centerInParent="true"
             android:src ="@drawable/splashtxt"/>
 
     </RelativeLayout>


### PR DESCRIPTION
notification type 에 변화가 있었습니다. 서버쪽 gam-push-module 에서 의무적으로 notification_type 을 지정하고,

클라이언트에서는 해당 notification_type의 true, false 를 구분해서 노티를 보낼지 말지를 결정합니다.
여기서 주의할점은 true여야 합니다. 대문자가 섞이면 안됩니다
