### PR TITLE
로그인화면에서 실행되지 않던 버그 수정 (API 19)

### DIFF
--- a/app/src/main/java/com/mapzip/ppang/mapzipproject/adapter/MapzipApplication.java
+++ b/app/src/main/java/com/mapzip/ppang/mapzipproject/adapter/MapzipApplication.java
@@ -30,7 +30,7 @@ public class MapzipApplication extends Application {
     public void onCreate() {
         super.onCreate();
 
-        initMapzip(false); // release 할때는 false 로 바꿔주셔야 합니다
+        initMapzip(true); // release 할때는 false 로 바꿔주셔야 합니다
         initFabric();
 
 

--- a/app/src/main/java/com/mapzip/ppang/mapzipproject/main/LoginFragment.java
+++ b/app/src/main/java/com/mapzip/ppang/mapzipproject/main/LoginFragment.java
@@ -70,8 +70,7 @@ public class LoginFragment extends Fragment {
     private String auto_pw;
     private CheckBox check_auto;
 
-
-    public static LoginFragment create(int pageNumber,int isAuto,String auto_id, String auto_pw) {
+    public static LoginFragment create(int pageNumber, int isAuto, String auto_id, String auto_pw) {
 
         LoginFragment fragment = new LoginFragment();
         Bundle args = new Bundle();
@@ -107,7 +106,9 @@ public class LoginFragment extends Fragment {
         layout_toast = inflater.inflate(R.layout.my_custom_toast, (ViewGroup) getActivity().findViewById(R.id.custom_toast_layout));
         text_toast = (TextView) layout_toast.findViewById(R.id.textToShow);
 
-        ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.login_layout, container, false);
+        Log.v(TAG,"11111");
+        ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.login_layout, container,false);
+        Log.v(TAG,"22222");
 
         inputID = (EditText) rootView.findViewById(R.id.InputID);
         inputPW = (EditText) rootView.findViewById(R.id.InputPW);

--- a/app/src/main/res/layout/login_layout.xml
+++ b/app/src/main/res/layout/login_layout.xml
@@ -82,7 +82,7 @@
         android:background="@drawable/loginbtn"
         android:id="@+id/btnLogin" />
 
-    <CheckBox
+    <android.support.v7.widget.AppCompatCheckBox
         android:id="@+id/check_auto"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
login layout 의 checkbox를 appcompatCheckbox로 변경.
변경하지 않으면 API 19 환경의 폰에서 안돌아감. 변경 후 API 22 버전에서도 돌아가는 것 확인했음.
에뮬레이터가 실행되지 않아 다른버전에서는 확인 못해봤습니다!
